### PR TITLE
Decentralized alert keys

### DIFF
--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -158,7 +158,7 @@ bool CAlert::CheckSignature(const std::vector<unsigned char>& alertKey) const
     return true;
 }
 
-bool CAlert::CheckForAnyValidSignature(const std::vector<CAlertKeyData>& alertKeys) const
+bool CAlert::CheckForAnyValidSignature(const std::vector<CAlertKeyData>& alertKeys)
 {
     strSender.clear();
 

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -163,7 +163,7 @@ bool CAlert::CheckForAnyValidSignature(const std::vector<CAlertKeyData>& alertKe
     strSender.clear();
 
     // Loop through valid alert public keys and check if this signature is valid for any of them.
-    for (std::vector<CAlertKeyData>::iterator it = alertKeys.begin(); it != alertKeys.end(); ++it)
+    for (std::vector<CAlertKeyData>::const_iterator it = alertKeys.begin(); it != alertKeys.end(); ++it)
     {
         if (!CheckSignature(it->pubKey))
             continue;

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -87,7 +87,7 @@ void CAlert::SetNull()
     CUnsignedAlert::SetNull();
     vchMsg.clear();
     vchSig.clear();
-	strSender.clear();
+    strSender.clear();
 }
 
 bool CAlert::IsNull() const
@@ -149,8 +149,8 @@ bool CAlert::RelayTo(CNode* pnode) const
 bool CAlert::CheckSignature(const std::vector<unsigned char>& alertKey) const
 {
     CPubKey key(alertKey);
-	if (!key.Verify(Hash(vchMsg.begin(), vchMsg.end()), vchSig))
-		return false;
+    if (!key.Verify(Hash(vchMsg.begin(), vchMsg.end()), vchSig))
+        return false;
 
     // Now unserialize the data
     CDataStream sMsg(vchMsg, SER_NETWORK, PROTOCOL_VERSION);
@@ -160,20 +160,20 @@ bool CAlert::CheckSignature(const std::vector<unsigned char>& alertKey) const
 
 bool CAlert::CheckForAnyValidSignature(const std::vector<CAlertKeyData>& alertKeys) const
 {
-	// Loop through valid alert public keys and check if this signature is valid for any of them.
-	for (std::vector<CAlertKeyData>::iterator it = alertKeys.begin(); it != alertKeys.end(); ++it)
-	{
-		if (!CheckSignature(it.pubKey))
-			continue;
+    strSender.clear();
 
-		strSender = it.Owner;
+    // Loop through valid alert public keys and check if this signature is valid for any of them.
+    for (std::vector<CAlertKeyData>::iterator it = alertKeys.begin(); it != alertKeys.end(); ++it)
+    {
+        if (!CheckSignature(it.pubKey))
+            continue;
 
-		return true;
-	}
+        strSender = it.Owner;
 
-	strSender.clear();
+        return true;
+    }
 
-	return error("CAlert::CheckForAnyValidSignature(): verify signature failed for all alert keys");
+    return error("CAlert::CheckForAnyValidSignature(): verify signature failed for all alert keys");
 }
 
 CAlert CAlert::getAlertByHash(const uint256 &hash)
@@ -190,8 +190,8 @@ CAlert CAlert::getAlertByHash(const uint256 &hash)
 
 bool CAlert::ProcessAlert(const std::vector<CAlertKeyData>& alertKeys, bool fThread)
 {
-	if (!CheckForAnyValidSignature(alertKeys))
-		return false;
+    if (!CheckForAnyValidSignature(alertKeys))
+        return false;
 
     if (!IsInEffect())
         return false;

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -165,10 +165,10 @@ bool CAlert::CheckForAnyValidSignature(const std::vector<CAlertKeyData>& alertKe
     // Loop through valid alert public keys and check if this signature is valid for any of them.
     for (std::vector<CAlertKeyData>::iterator it = alertKeys.begin(); it != alertKeys.end(); ++it)
     {
-        if (!CheckSignature(it.pubKey))
+        if (!CheckSignature(it->pubKey))
             continue;
 
-        strSender = it.Owner;
+        strSender = it->owner;
 
         return true;
     }

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -87,6 +87,7 @@ void CAlert::SetNull()
     CUnsignedAlert::SetNull();
     vchMsg.clear();
     vchSig.clear();
+	strSender.clear();
 }
 
 bool CAlert::IsNull() const
@@ -148,13 +149,31 @@ bool CAlert::RelayTo(CNode* pnode) const
 bool CAlert::CheckSignature(const std::vector<unsigned char>& alertKey) const
 {
     CPubKey key(alertKey);
-    if (!key.Verify(Hash(vchMsg.begin(), vchMsg.end()), vchSig))
-        return error("CAlert::CheckSignature(): verify signature failed");
+	if (!key.Verify(Hash(vchMsg.begin(), vchMsg.end()), vchSig))
+		return false;
 
     // Now unserialize the data
     CDataStream sMsg(vchMsg, SER_NETWORK, PROTOCOL_VERSION);
     sMsg >> *(CUnsignedAlert*)this;
     return true;
+}
+
+bool CAlert::CheckForAnyValidSignature(const std::vector<CAlertKeyData>& alertKeys) const
+{
+	// Loop through valid alert public keys and check if this signature is valid for any of them.
+	for (std::vector<CAlertKeyData>::iterator it = alertKeys.begin(); it != alertKeys.end(); ++it)
+	{
+		if (!CheckSignature(it.pubKey))
+			continue;
+
+		strSender = it.Owner;
+
+		return true;
+	}
+
+	strSender.clear();
+
+	return error("CAlert::CheckForAnyValidSignature(): verify signature failed for all alert keys");
 }
 
 CAlert CAlert::getAlertByHash(const uint256 &hash)
@@ -169,10 +188,11 @@ CAlert CAlert::getAlertByHash(const uint256 &hash)
     return retval;
 }
 
-bool CAlert::ProcessAlert(const std::vector<unsigned char>& alertKey, bool fThread)
+bool CAlert::ProcessAlert(const std::vector<CAlertKeyData>& alertKeys, bool fThread)
 {
-    if (!CheckSignature(alertKey))
-        return false;
+	if (!CheckForAnyValidSignature(alertKeys))
+		return false;
+
     if (!IsInEffect())
         return false;
 

--- a/src/alert.h
+++ b/src/alert.h
@@ -22,9 +22,9 @@ extern std::map<uint256, CAlert> mapAlerts;
 extern CCriticalSection cs_mapAlerts;
 
 struct CAlertKeyData {
-	std::string owner;
-	std::vector<unsigned char> pubKey;
-	CAlertKeyData(const std::string &strOwner, const std::vector<unsigned char> &vPubKey) : owner(strOwner), pubKey(vPubKey) {}
+    std::string owner;
+    std::vector<unsigned char> pubKey;
+    CAlertKeyData(const std::string &strOwner, const std::vector<unsigned char> &vPubKey) : owner(strOwner), pubKey(vPubKey) {}
 };
 
 /** Alerts are for notifying old versions if they become too obsolete and
@@ -84,7 +84,7 @@ class CAlert : public CUnsignedAlert
 public:
     std::vector<unsigned char> vchMsg;
     std::vector<unsigned char> vchSig;
-	std::string strSender;
+    std::string strSender;
 
     CAlert()
     {

--- a/src/alert.h
+++ b/src/alert.h
@@ -108,7 +108,8 @@ public:
     bool AppliesToMe() const;
     bool RelayTo(CNode* pnode) const;
     bool CheckSignature(const std::vector<unsigned char>& alertKey) const;
-    bool ProcessAlert(const std::vector<unsigned char>& alertKey, bool fThread = true); // fThread means run -alertnotify in a free-running thread
+    bool CheckForAnyValidSignature(const std::vector<CAlertKeyData>& alertKeys);
+    bool ProcessAlert(const std::vector<CAlertKeyData>& alertKeys, bool fThread = true); // fThread means run -alertnotify in a free-running thread
     static void Notify(const std::string& strMessage, bool fThread);
 
     /*

--- a/src/alert.h
+++ b/src/alert.h
@@ -21,6 +21,12 @@ class uint256;
 extern std::map<uint256, CAlert> mapAlerts;
 extern CCriticalSection cs_mapAlerts;
 
+struct CAlertKeyData {
+	std::string owner;
+	std::vector<unsigned char> pubKey;
+	CAlertKeyData(const std::string &strOwner, const std::vector<unsigned char> &vPubKey) : owner(strOwner), pubKey(vPubKey) {}
+};
+
 /** Alerts are for notifying old versions if they become too obsolete and
  * need to upgrade.  The message is displayed in the status bar.
  * Alert messages are broadcast as a vector of signed data.  Unserializing may
@@ -78,6 +84,7 @@ class CAlert : public CUnsignedAlert
 public:
     std::vector<unsigned char> vchMsg;
     std::vector<unsigned char> vchSig;
+	std::string strSender;
 
     CAlert()
     {

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -90,8 +90,13 @@ public:
         pchMessageStart[1] = 0xbe;
         pchMessageStart[2] = 0xb4;
         pchMessageStart[3] = 0xd9;
-        vAlertPubKey = ParseHex("04fc9702847840aaf195de8442ebecedf5b095cdbb9bc716bda9110971b28a49e0ead8564ff0db22209e0374782c093bb899692d524e9d6a6956e7c5ecbcd68284");
-        nDefaultPort = 8333;
+		vAlertKeys.push_back(CAlertKeyData("Bitcoin Core", ParseHex("04fc9702847840aaf195de8442ebecedf5b095cdbb9bc716bda9110971b28a49e0ead8564ff0db22209e0374782c093bb899692d524e9d6a6956e7c5ecbcd68284")));  // The original bitcoin alert key
+		// TODO: Decide who should get keys... lead devs of major clients? people elected from the community?
+		//vAlertKeys.push_back(CAlertKeyData("Gavin Andresen", ParseHex("00deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")));
+		//vAlertKeys.push_back(CAlertKeyData("Jonathan Toomim (Bitcoin Classic)", ParseHex("00deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")));
+		//vAlertKeys.push_back(CAlertKeyData("Andrew Stone (Bitcoin Unlimited)", ParseHex("00deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")));
+		//vAlertKeys.push_back(CAlertKeyData("Tom Harding (BitcoinXT)", ParseHex("00deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")));
+		nDefaultPort = 8333;
         nMaxTipAge = 24 * 60 * 60;
         nPruneAfterHeight = 100000;
 
@@ -167,7 +172,7 @@ public:
         pchMessageStart[1] = 0x11;
         pchMessageStart[2] = 0x09;
         pchMessageStart[3] = 0x07;
-        vAlertPubKey = ParseHex("04302390343f91cc401d56d68b123028bf52e5fca1939df127f63c6467cdf9c8e2c14b61104cf817d0b780da337893ecc4aaff1309e536162dabbdb45200ca2b0a");
+		vAlertKeys.push_back(CAlertKeyData("TestNet Alert Key", ParseHex("04302390343f91cc401d56d68b123028bf52e5fca1939df127f63c6467cdf9c8e2c14b61104cf817d0b780da337893ecc4aaff1309e536162dabbdb45200ca2b0a")));
         nDefaultPort = 18333;
         nMaxTipAge = 0x7fffffff;
         nPruneAfterHeight = 1000;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -90,13 +90,13 @@ public:
         pchMessageStart[1] = 0xbe;
         pchMessageStart[2] = 0xb4;
         pchMessageStart[3] = 0xd9;
-		vAlertKeys.push_back(CAlertKeyData("Bitcoin Core", ParseHex("04fc9702847840aaf195de8442ebecedf5b095cdbb9bc716bda9110971b28a49e0ead8564ff0db22209e0374782c093bb899692d524e9d6a6956e7c5ecbcd68284")));  // The original bitcoin alert key
-		// TODO: Decide who should get keys... lead devs of major clients? people elected from the community?
-		//vAlertKeys.push_back(CAlertKeyData("Gavin Andresen", ParseHex("00deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")));
-		//vAlertKeys.push_back(CAlertKeyData("Jonathan Toomim (Bitcoin Classic)", ParseHex("00deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")));
-		//vAlertKeys.push_back(CAlertKeyData("Andrew Stone (Bitcoin Unlimited)", ParseHex("00deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")));
-		//vAlertKeys.push_back(CAlertKeyData("Tom Harding (BitcoinXT)", ParseHex("00deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")));
-		nDefaultPort = 8333;
+        vAlertKeys.push_back(CAlertKeyData("Bitcoin Core", ParseHex("04fc9702847840aaf195de8442ebecedf5b095cdbb9bc716bda9110971b28a49e0ead8564ff0db22209e0374782c093bb899692d524e9d6a6956e7c5ecbcd68284")));  // The original bitcoin alert key
+        // TODO: Decide who should get keys... lead devs of major clients? people elected from the community?
+        //vAlertKeys.push_back(CAlertKeyData("Gavin Andresen", ParseHex("00deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")));
+        //vAlertKeys.push_back(CAlertKeyData("Jonathan Toomim (Bitcoin Classic)", ParseHex("00deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")));
+        //vAlertKeys.push_back(CAlertKeyData("Andrew Stone (Bitcoin Unlimited)", ParseHex("00deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")));
+        //vAlertKeys.push_back(CAlertKeyData("Tom Harding (BitcoinXT)", ParseHex("00deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")));
+        nDefaultPort = 8333;
         nMaxTipAge = 24 * 60 * 60;
         nPruneAfterHeight = 100000;
 
@@ -172,7 +172,7 @@ public:
         pchMessageStart[1] = 0x11;
         pchMessageStart[2] = 0x09;
         pchMessageStart[3] = 0x07;
-		vAlertKeys.push_back(CAlertKeyData("TestNet Alert Key", ParseHex("04302390343f91cc401d56d68b123028bf52e5fca1939df127f63c6467cdf9c8e2c14b61104cf817d0b780da337893ecc4aaff1309e536162dabbdb45200ca2b0a")));
+        vAlertKeys.push_back(CAlertKeyData("TestNet Alert Key", ParseHex("04302390343f91cc401d56d68b123028bf52e5fca1939df127f63c6467cdf9c8e2c14b61104cf817d0b780da337893ecc4aaff1309e536162dabbdb45200ca2b0a")));
         nDefaultPort = 18333;
         nMaxTipAge = 0x7fffffff;
         nPruneAfterHeight = 1000;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -6,6 +6,7 @@
 #ifndef BITCOIN_CHAINPARAMS_H
 #define BITCOIN_CHAINPARAMS_H
 
+#include "alert.h"
 #include "chainparamsbase.h"
 #include "consensus/params.h"
 #include "primitives/block.h"
@@ -54,7 +55,7 @@ public:
 
     const Consensus::Params& GetConsensus() const { return consensus; }
     const CMessageHeader::MessageStartChars& MessageStart() const { return pchMessageStart; }
-    const std::vector<unsigned char>& AlertKey() const { return vAlertPubKey; }
+    const std::vector<CAlertKeyData>& AlertKeys() const { return vAlertKeys; }
     int GetDefaultPort() const { return nDefaultPort; }
 
     const CBlock& GenesisBlock() const { return genesis; }
@@ -82,7 +83,7 @@ protected:
     Consensus::Params consensus;
     CMessageHeader::MessageStartChars pchMessageStart;
     //! Raw pub key bytes for the broadcast alert signing key.
-    std::vector<unsigned char> vAlertPubKey;
+    std::vector<CAlertKeyData> vAlertKeys;
     int nDefaultPort;
     long nMaxTipAge;
     uint64_t nPruneAfterHeight;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5071,7 +5071,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         uint256 alertHash = alert.GetHash();
         if (pfrom->setKnown.count(alertHash) == 0)
         {
-            if (alert.ProcessAlert(chainparams.AlertKey()))
+            if (alert.ProcessAlert(chainparams.AlertKeys()))
             {
                 // Relay
                 pfrom->setKnown.insert(alertHash);

--- a/src/test/alert_tests.cpp
+++ b/src/test/alert_tests.cpp
@@ -119,11 +119,11 @@ BOOST_FIXTURE_TEST_SUITE(Alert_tests, ReadAlerts)
 BOOST_AUTO_TEST_CASE(AlertApplies)
 {
     SetMockTime(11);
-    const std::vector<unsigned char>& alertKey = Params(CBaseChainParams::MAIN).AlertKey();
+    const std::vector<CAlertKeyData>& alertKeys = Params(CBaseChainParams::MAIN).AlertKeys();
 
     BOOST_FOREACH(const CAlert& alert, alerts)
     {
-        BOOST_CHECK(alert.CheckSignature(alertKey));
+        BOOST_CHECK(alert.CheckForAnyValidSignature(alertKeys));
     }
 
     BOOST_CHECK(alerts.size() >= 3);
@@ -160,7 +160,7 @@ BOOST_AUTO_TEST_CASE(AlertApplies)
 BOOST_AUTO_TEST_CASE(AlertNotify)
 {
     SetMockTime(11);
-    const std::vector<unsigned char>& alertKey = Params(CBaseChainParams::MAIN).AlertKey();
+    const std::vector<CAlertKeyData>& alertKeys = Params(CBaseChainParams::MAIN).AlertKeys();
 
     boost::filesystem::path temp = GetTempPath() /
         boost::filesystem::unique_path("alertnotify-%%%%.txt");
@@ -168,7 +168,7 @@ BOOST_AUTO_TEST_CASE(AlertNotify)
     mapArgs["-alertnotify"] = std::string("echo %s >> ") + temp.string();
 
     BOOST_FOREACH(CAlert alert, alerts)
-        alert.ProcessAlert(alertKey, false);
+        alert.ProcessAlert(alertKeys, false);
 
     std::vector<std::string> r = read_lines(temp);
     BOOST_CHECK_EQUAL(r.size(), 4u);

--- a/src/test/alert_tests.cpp
+++ b/src/test/alert_tests.cpp
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE(AlertApplies)
     SetMockTime(11);
     const std::vector<CAlertKeyData>& alertKeys = Params(CBaseChainParams::MAIN).AlertKeys();
 
-    BOOST_FOREACH(const CAlert& alert, alerts)
+    BOOST_FOREACH(CAlert& alert, alerts)
     {
         BOOST_CHECK(alert.CheckForAnyValidSignature(alertKeys));
     }


### PR DESCRIPTION
Adds support for multiple valid alert keys, including the original Bitcoin alert known to Themos, Gavin, Satoshi, and possibly others.

Allows for a short list of key community members, to be alert key holders, and for the UI to display who the alert was originally sent from.  This would be a non-forking change, alerts signed by a recognized alert key are relayed, alerts signed by a unrecognized alert key are not.
